### PR TITLE
Render queue

### DIFF
--- a/examples/scene_in_qt_subwidget.py
+++ b/examples/scene_in_qt_subwidget.py
@@ -17,6 +17,7 @@ class Main(QtWidgets.QWidget):
         self._canvas = WgpuCanvas(parent=self)
         self._renderer = vv.WgpuSurfaceRenderer(self._canvas)
         self._scene = vv.Scene()
+        self._camera = vv.PerspectiveCamera(45, 16/9, 0.1, 1000)
 
         # Hook up the animate callback
         self._canvas.draw_frame = self.animate
@@ -32,8 +33,10 @@ class Main(QtWidgets.QWidget):
         self._canvas.update()
 
     def animate(self):
-        camera = None
-        self._renderer.render(self._scene, camera)
+        width, height, ratio = self._canvas.get_size_and_pixel_ratio()
+        self._camera.aspect = width / height
+        self._camera.update_projection_matrix()
+        self._renderer.render(self._scene, self._camera)
 
 
 app = QtWidgets.QApplication([])

--- a/examples/scene_in_qt_subwidget.py
+++ b/examples/scene_in_qt_subwidget.py
@@ -17,7 +17,7 @@ class Main(QtWidgets.QWidget):
         self._canvas = WgpuCanvas(parent=self)
         self._renderer = vv.WgpuSurfaceRenderer(self._canvas)
         self._scene = vv.Scene()
-        self._camera = vv.PerspectiveCamera(45, 16/9, 0.1, 1000)
+        self._camera = vv.PerspectiveCamera(45, 16 / 9, 0.1, 1000)
 
         # Hook up the animate callback
         self._canvas.draw_frame = self.animate

--- a/examples/simple_scene.py
+++ b/examples/simple_scene.py
@@ -17,11 +17,13 @@ for i in range(20):
     scene.add(vv.Mesh(vv.Geometry(), vv.TriangleMaterial()))
 
 
-camera = vv.Camera()
-camera.projection_matrix.identity()
+camera = vv.PerspectiveCamera(45, 16/9, 0.1, 1000)
 
 
 def animate():
+    width, height, ratio = canvas.get_size_and_pixel_ratio()
+    camera.aspect = width / height
+    camera.update_projection_matrix()
     # Actually render the scene
     renderer.render(scene, camera)
 

--- a/examples/simple_scene.py
+++ b/examples/simple_scene.py
@@ -17,7 +17,7 @@ for i in range(20):
     scene.add(vv.Mesh(vv.Geometry(), vv.TriangleMaterial()))
 
 
-camera = vv.PerspectiveCamera(45, 16/9, 0.1, 1000)
+camera = vv.PerspectiveCamera(45, 16 / 9, 0.1, 1000)
 
 
 def animate():

--- a/visvis2/cameras/_base.py
+++ b/visvis2/cameras/_base.py
@@ -9,3 +9,6 @@ class Camera(WorldObject):
         self.matrix_world_inverse = Matrix4()
         self.projection_matrix = Matrix4()
         self.projection_matrix_inverse = Matrix4()
+
+    def update_projection_matrix(self):
+        raise NotImplementedError()

--- a/visvis2/cameras/_perspective.py
+++ b/visvis2/cameras/_perspective.py
@@ -14,6 +14,9 @@ class PerspectiveCamera(Camera):
 
         self.update_projection_matrix()
 
+    def __repr__(self) -> str:
+        return f"PerspectiveCamera({self.fov}, {self.aspect}, {self.near}, {self.far})"
+
     def update_matrix_world(self, *args, **kwargs):
         super().update_matrix_world(*args, **kwargs)
         self.matrix_world_inverse.get_inverse(self.matrix_world)

--- a/visvis2/linalg/vector3.py
+++ b/visvis2/linalg/vector3.py
@@ -149,7 +149,13 @@ class Vector3:
         x, y, z = self.x, self.y, self.z
         e = m.elements
 
-        w = 1 / (e[3] * x + e[7] * y + e[11] * z + e[15])
+        denom = e[3] * x + e[7] * y + e[11] * z + e[15]
+        if denom == 0:
+            w = float('Inf')
+        elif denom == -0:
+            w = float('-Inf')
+        else:
+            w = 1 / denom
         self.x = (e[0] * x + e[4] * y + e[8] * z + e[12]) * w
         self.y = (e[1] * x + e[5] * y + e[9] * z + e[13]) * w
         self.z = (e[2] * x + e[6] * y + e[10] * z + e[14]) * w

--- a/visvis2/linalg/vector3.py
+++ b/visvis2/linalg/vector3.py
@@ -151,9 +151,9 @@ class Vector3:
 
         denom = e[3] * x + e[7] * y + e[11] * z + e[15]
         if denom == 0:
-            w = float('Inf')
+            w = float("Inf")
         elif denom == -0:
-            w = float('-Inf')
+            w = float("-Inf")
         else:
             w = 1 / denom
         self.x = (e[0] * x + e[4] * y + e[8] * z + e[12]) * w

--- a/visvis2/objects/_world_object.py
+++ b/visvis2/objects/_world_object.py
@@ -17,6 +17,9 @@ class WorldObject:
         self.matrix_world = Matrix4()
         self.matrix_world_dirty = True
 
+        self.visible = True
+        self.render_order = 0
+
     @property
     def children(self):
         return tuple(self._children)

--- a/visvis2/renderers/_wgpu.py
+++ b/visvis2/renderers/_wgpu.py
@@ -3,7 +3,9 @@ import ctypes
 import wgpu.backend.rs
 
 from ._base import Renderer
-from ..objects import Mesh
+from ..objects import Mesh, WorldObject
+from ..cameras import Camera
+from ..linalg import Matrix4, Vector3
 
 
 class WgpuBaseRenderer(Renderer):
@@ -33,17 +35,28 @@ class WgpuSurfaceRenderer(WgpuBaseRenderer):
             wgpu.TextureUsage.OUTPUT_ATTACHMENT,
         )
 
-    def traverse(self, obj):
-        yield obj
-        for child in obj.children:
-            yield from self.traverse(child)
+    def get_render_list(self, scene: WorldObject, proj_screen_matrix: Matrix4):
+        # start by gathering everything that is visible and has a material
+        q = []
+        def visit(wobject):
+            nonlocal q
+            if wobject.visible and hasattr(wobject, "material"):
+                q.append(wobject)       
+        scene.traverse(visit)
+        
+        # next, sort them from back-to-front
+        def sort_func(wobject: WorldObject):
+            z = Vector3().set_from_matrix_position(wobject.matrix_world).apply_matrix4(proj_screen_matrix).z
+            return wobject.render_order, z
+        q = tuple(sorted(q, key=sort_func))
+        
+        # finally ensure they have pipeline info
+        for wobject in q:
+            wobject._pipeline_info = self.compose_pipeline(wobject)
+        return q
 
     def compose_pipeline(self, wobject):
         device = self._device
-
-        # object type determines pipeline composition
-        if not isinstance(wobject, Mesh):
-            return None, None, None
 
         if not wobject.material.dirty and hasattr(wobject, "_pipeline_info"):
             return wobject._pipeline_info
@@ -155,14 +168,19 @@ class WgpuSurfaceRenderer(WgpuBaseRenderer):
         wobject.material.dirty = False
         return pipeline, bind_group, vertex_buffers
 
-    def render(self, scene, camera):
+    def render(self, scene: WorldObject, camera: Camera):
         # Called by figure/canvas
 
         device = self._device
 
-        # First make sure that all objects in the scene have a pipeline
-        for obj in self.traverse(scene):
-            obj._pipeline_info = self.compose_pipeline(obj)
+        # ensure all world matrices are up to date
+        scene.update_matrix_world()
+        # ensure camera projection matrix is up to date
+        camera.update_projection_matrix()
+        # compute the screen projection matrix
+        proj_screen_matrix = Matrix4().multiply_matrices(camera.projection_matrix, camera.matrix_world_inverse)
+        # get the sorted list of objects to render (guaranteed to be visible and having a material)
+        q = self.get_render_list(scene, proj_screen_matrix)
 
         current_texture_view = self._swap_chain.get_current_texture_view()
         command_encoder = device.create_command_encoder()
@@ -182,7 +200,7 @@ class WgpuSurfaceRenderer(WgpuBaseRenderer):
             depth_stencil_attachment=None,
         )
 
-        for obj in self.traverse(scene):
+        for obj in q:
             pipeline, bind_group, vertex_buffers = obj._pipeline_info
 
             if pipeline is None:


### PR DESCRIPTION
* `render()` starts by extracting ordered list of world objects to render and ensuring their matrices are up to date
* Sorts objects by view space z-axis
* User can override sorting order with `WorldObject.render_order`
* New function also filters out invisible (`WorldObject.visible`) and unrenderable (no `material`) world objects
* Fixed bug in `Vector3.apply_matrix4` handling division by zero
* Modified examples accordingly