### PR TITLE
Update camera world matrix

### DIFF
--- a/visvis2/renderers/_wgpu.py
+++ b/visvis2/renderers/_wgpu.py
@@ -183,8 +183,8 @@ class WgpuSurfaceRenderer(WgpuBaseRenderer):
 
         # ensure all world matrices are up to date
         scene.update_matrix_world()
-        # ensure camera projection matrix is up to date
-        camera.update_projection_matrix()
+        # ensure camera world matrix is up to date (it may not be member of the scene)
+        camera.update_matrix_world()
         # compute the screen projection matrix
         proj_screen_matrix = Matrix4().multiply_matrices(
             camera.projection_matrix, camera.matrix_world_inverse


### PR DESCRIPTION
I realized that the world matrix is the thing that the renderer is responsible for, the user is responsible for the projection matrix (and that is also already accounted for in all three examples). So this fixes a bug since the camera world matrix was never updated.